### PR TITLE
Add initial working Dockerfile for the frontend.

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:23-alpine
+
+RUN mkdir -p /home/node/app/node_modules
+
+WORKDIR /home/node/app
+
+COPY package*.json ./
+
+RUN chown -R node:node /home/node/app
+
+USER node
+
+RUN npm install
+
+COPY --chown=node:node . .
+
+EXPOSE 3000
+
+CMD [ "npm", "start" ]


### PR DESCRIPTION
Initial attempt at a Dockerfile for the frontend.

This uses the 'alpine' version of 'node' to keep the image small.

Possible issues:
 - running this on docker does not react to SIGTERM (CTRL-C), you have to use 'docker stop resume-ai-frontend'.
 - Does the image need to be versioned?

Building:
In the frontend/ folder, run:
   sudo docker build -t resume-ai-frontend .

Running:
   sudo docker run --name resume-ai-frontend -p 3000:3000 resume-ai-frontend:latest